### PR TITLE
change version number for visability backend

### DIFF
--- a/ExactConnectorHelper/plugin.xml
+++ b/ExactConnectorHelper/plugin.xml
@@ -4,7 +4,7 @@
     <label lang="en">Exact Connector Helper</label>
     <label lang="de">Exact Connector Helper</label>
     <label lang="nl">Exact Connector Helper</label>
-    <version>2.2.3</version>
+    <version>2.2.5</version>
     <copyright>(c) by dealer4dealer</copyright>
     <license>proprietary</license>
     <author>dealer4dealer</author>


### PR DESCRIPTION
Last update and this update the version number in plugin.xml hasn't changed so the sw5 backend still shows v.2.2.5